### PR TITLE
Disable built in tomcat log rotation - rename logs

### DIFF
--- a/server.xml
+++ b/server.xml
@@ -113,7 +113,13 @@
         <!-- Access log processes all example.
              Documentation at: /docs/config/valve.html
              Note: The pattern used is equivalent to using pattern="common" -->
-        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs" prefix="localhost_access_log." suffix=".txt" pattern="%h %l %u %t &quot;%r&quot; %s %b"/>
+      <Valve className="org.apache.catalina.valves.AccessLogValve"
+             directory="logs"
+             prefix="localhost_access."
+             suffix="log"
+             pattern="%h %l %u %t &quot;%r&quot; %s %b"
+             rotatable="false"
+             />
       </Host>
     </Engine>
     <Connector minSpareThreads="25" acceptCount="100" scheme="https" secure="true" SSLEnabled="true" port="8443" enableLookups="true" keystoreFile="conf/keystore" URIEncoding="UTF-8"/>


### PR DESCRIPTION
Tomcat doesn't do a good job of rotating the logs. It never removes and
cleans up old logs. By disabling tomcat rotation, the dates are then
removed from the filenames. Our existing configs for tomcat logfile
rotation in logrotated looks for *.log and will function nicely with
this new naming convention.